### PR TITLE
feat(account/user): mover validações de payload para serializer e retornar 400 caso usuário já esteja cadastrado

### DIFF
--- a/machado/account/serializers.py
+++ b/machado/account/serializers.py
@@ -5,3 +5,33 @@ class UserSerializer(serializers.ModelSerializer):
     class Meta:
         model = User
         fields = ['id', 'username', 'email', 'first_name', 'last_name', 'is_staff']
+
+class UserCreateSerializer(serializers.Serializer):
+    username = serializers.CharField(min_length=3, max_length=150)
+    email = serializers.EmailField()
+    password = serializers.CharField(min_length=3, write_only=True)
+    first_name = serializers.CharField(required=False, allow_blank=True, max_length=150)
+    last_name = serializers.CharField(required=False, allow_blank=True, max_length=150)
+    is_staff = serializers.BooleanField(default=False)
+
+    def validate_username(self, value):
+        if User.objects.filter(username=value).exists():
+            raise serializers.ValidationError("Um usuário com este nome de usuário já existe.")
+        return value
+
+    def validate_email(self, value):
+        if User.objects.filter(email=value).exists():
+            raise serializers.ValidationError("Um usuário com este e-mail já existe.")
+        return value
+
+    def create(self, validated_data):
+        is_staff = validated_data.pop('is_staff', False)
+        user = User.objects.create_user(
+            username=validated_data['username'],
+            email=validated_data['email'],
+            password=validated_data['password'],
+            first_name=validated_data.get('first_name', ''),
+            last_name=validated_data.get('last_name', ''),
+            is_staff=is_staff
+        )
+        return user


### PR DESCRIPTION
Este PR refatora a lógica de criação de usuário movendo as **validações de payload** da view `AdminUserActions.create` para o **`UserCreateSerializer`**.

**O que foi feito:**

* **Removida a lógica de validação manual** (verificação de campos obrigatórios, tamanho mínimo de username/password, e regex de email) da view `AdminUserActions.create`.
* **Centralizada a validação no `UserCreateSerializer`**, utilizando os campos e métodos de validação embutidos do DRF.
* **Adicionada verificação no serializer** para garantir que um novo usuário não seja criado se já existir um usuário com o mesmo username ou email, retornando um `HTTP 400 Bad Request` nesses casos.